### PR TITLE
use default import for isDev to avoid an object value

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow } from 'electron';
 import * as path from 'path';
-import * as isDev from 'electron-is-dev';
+import isDev from 'electron-is-dev';
 
 function createWindow() {
   const win = new BrowserWindow({


### PR DESCRIPTION
I noticed this when trying to publish my app that the resulting value for `isDev` was an object of the form `{ default: false }` hence it is always truthy in the codebase.

This change is importing the default right off the bat so the resulting value is simply the boolean `false` or `true`