### PR TITLE
fix(ci): correct lint command in build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Dependencies
         run: |
           npm install
-          npm lint
+          npm run lint
         working-directory: .
 
       - name: Build Electron App


### PR DESCRIPTION
Fixes the CI workflow bug found in the repo monitor review.

The workflow was running `npm lint` (invalid command) instead of `npm run lint`. Every PR run has been failing at this step with 'Unknown command: lint'.

This is the root cause of all build-and-test failures across all open PRs in the repo.