### PR TITLE
fix: remove unused screen import from electron/main.ts

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, Tray, Menu, nativeImage, screen } from 'electron';
+import { app, BrowserWindow, ipcMain, Tray, Menu, nativeImage } from 'electron';
 import * as path from 'path';
 
 // Check if running in development mode


### PR DESCRIPTION
Pre-existing lint error discovered during the repo monitor review. The `screen` import in `electron/main.ts` was unused (the variable was never referenced).

CI `build-and-test` workflow was failing for ALL PRs due to this lint error after the workflow fix in #68 was applied. This resolves the remaining CI failure for PRs [#63](https://github.com/romankurnovskii/electron-react-template/pull/63), [#64](https://github.com/romankurnovskii/electron-react-template/pull/64), [#66](https://github.com/romankurnovskii/electron-react-template/pull/66), [#67](https://github.com/romankurnovskii/electron-react-template/pull/67).

Closes #68 (follow-up fix).